### PR TITLE
Use `Math.Cbrt` if available

### DIFF
--- a/HyperJet/Math.Cbrt.cs
+++ b/HyperJet/Math.Cbrt.cs
@@ -6,7 +6,11 @@ public static partial class MathD
 {
     public static D1Scalar Cbrt(D1Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D1Scalar.Forward(constant, da, a);
@@ -14,7 +18,11 @@ public static partial class MathD
 
     public static D2Scalar Cbrt(D2Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D2Scalar.Forward(constant, da, a);
@@ -22,7 +30,11 @@ public static partial class MathD
 
     public static D3Scalar Cbrt(D3Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D3Scalar.Forward(constant, da, a);
@@ -30,7 +42,11 @@ public static partial class MathD
 
     public static D4Scalar Cbrt(D4Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D4Scalar.Forward(constant, da, a);
@@ -38,7 +54,11 @@ public static partial class MathD
 
     public static D5Scalar Cbrt(D5Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D5Scalar.Forward(constant, da, a);
@@ -46,7 +66,11 @@ public static partial class MathD
 
     public static D6Scalar Cbrt(D6Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D6Scalar.Forward(constant, da, a);
@@ -54,7 +78,11 @@ public static partial class MathD
 
     public static D7Scalar Cbrt(D7Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D7Scalar.Forward(constant, da, a);
@@ -62,7 +90,11 @@ public static partial class MathD
 
     public static D8Scalar Cbrt(D8Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D8Scalar.Forward(constant, da, a);
@@ -70,7 +102,11 @@ public static partial class MathD
 
     public static D9Scalar Cbrt(D9Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D9Scalar.Forward(constant, da, a);
@@ -78,7 +114,11 @@ public static partial class MathD
 
     public static D10Scalar Cbrt(D10Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D10Scalar.Forward(constant, da, a);
@@ -86,7 +126,11 @@ public static partial class MathD
 
     public static D11Scalar Cbrt(D11Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D11Scalar.Forward(constant, da, a);
@@ -94,7 +138,11 @@ public static partial class MathD
 
     public static D12Scalar Cbrt(D12Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return D12Scalar.Forward(constant, da, a);
@@ -102,7 +150,11 @@ public static partial class MathD
 
     public static DD1Scalar Cbrt(DD1Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -111,7 +163,11 @@ public static partial class MathD
 
     public static DD2Scalar Cbrt(DD2Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -120,7 +176,11 @@ public static partial class MathD
 
     public static DD3Scalar Cbrt(DD3Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -129,7 +189,11 @@ public static partial class MathD
 
     public static DD4Scalar Cbrt(DD4Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -138,7 +202,11 @@ public static partial class MathD
 
     public static DD5Scalar Cbrt(DD5Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -147,7 +215,11 @@ public static partial class MathD
 
     public static DD6Scalar Cbrt(DD6Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -156,7 +228,11 @@ public static partial class MathD
 
     public static DD7Scalar Cbrt(DD7Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -165,7 +241,11 @@ public static partial class MathD
 
     public static DD8Scalar Cbrt(DD8Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -174,7 +254,11 @@ public static partial class MathD
 
     public static DD9Scalar Cbrt(DD9Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -183,7 +267,11 @@ public static partial class MathD
 
     public static DD10Scalar Cbrt(DD10Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -192,7 +280,11 @@ public static partial class MathD
 
     public static DD11Scalar Cbrt(DD11Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 
@@ -201,7 +293,11 @@ public static partial class MathD
 
     public static DD12Scalar Cbrt(DD12Scalar a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 

--- a/HyperJet/Math.Cbrt.tt
+++ b/HyperJet/Math.Cbrt.tt
@@ -18,7 +18,11 @@ for (var size = 1; size <= 12; size++)
 #>
     public static <#= scalar #> Cbrt(<#= scalar #> a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
 
         return <#= scalar #>.Forward(constant, da, a);
@@ -40,7 +44,11 @@ for (var size = 1; size <= 12; size++)
 #>
     public static <#= scalar #> Cbrt(<#= scalar #> a)
     {
+#if NETSTANDARD2_1_OR_GREATER
+        var constant = Math.Cbrt(a.Constant);
+#else
         var constant = Math.Pow(a.Constant, 1.0 / 3.0);
+#endif
         var da = 1 / (3 * constant * constant);
         var dada = -da * 2 / (3 * a.Constant);
 


### PR DESCRIPTION
Use build-in `Math.Cbrt` insead of `Math.Pow` if .NET Standard > 2.1.